### PR TITLE
centred and (slightly) bolded explainer line

### DIFF
--- a/_includes/content-briefs.html
+++ b/_includes/content-briefs.html
@@ -1,5 +1,5 @@
 <div id='briefs' class='content-div'>
-  <p>Concise yet thorough articles that summarize and comment on an important recent AI story.</p>
+  <p id="explainer">Concise yet thorough articles that summarize and comment on an important recent AI story.</p>
   <ul class="post-list" id="briefs-list"> 
     {% for post in site.categories.briefs %} 
       {% include entry.html %}

--- a/_includes/content-digests.html
+++ b/_includes/content-digests.html
@@ -1,5 +1,5 @@
 <div id='digests' class='content-div' style="display:none" >
-  <p>A bi-weekly newsletter with quick takes on the most important recent media stories about AI.</p>
+  <p id="explainer">A bi-weekly newsletter with quick takes on the most important recent media stories about AI.</p>
   <ul class="post-list" id="digests-list"> 
     {% for post in site.categories.digests %} 
       {% include entry.html %}

--- a/_includes/content-editorials.html
+++ b/_includes/content-editorials.html
@@ -1,5 +1,5 @@
 <div id='editorials' style="display:none" class='content-div'>
-  <p>Longer and more in-depth pieces that are more opinionated and less news-specific.</p>
+  <p id="explainer">Longer and more in-depth pieces that are more opinionated and less news-specific.</p>
   <ul class="post-list" id="editorials-list">
     {% for post in site.categories.editorials %}
       {% include entry.html %}

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -469,3 +469,8 @@ figcaption {
 	} 
 }
 
+
+#explainer {
+   text-align: center;
+   font-weight: 500;
+}


### PR DESCRIPTION
feel free to increase the font-weight.
However, on desktop, when setting to anything > 500 one word of the explainer line overflows and looks weird.