### PR TITLE
Replaced deprecated 'srcElement' reference with 'target' in toggle.js

### DIFF
--- a/assets/js/toggle.js
+++ b/assets/js/toggle.js
@@ -3,7 +3,7 @@ $(function() {
     document.querySelector("#writingToggleForm").addEventListener("change", function(event) {
         console.log("Toggling writing display!");
         currentDisplay.fadeToggle(function() {
-            currentDisplay = $(event.srcElement.getAttribute("data-st-contentid"));
+            currentDisplay = $(event.target.getAttribute("data-st-contentid"));
             currentDisplay.fadeToggle();
         });
     });


### PR DESCRIPTION
see https://stackoverflow.com/questions/5301643/how-can-i-make-event-srcelement-work-in-firefox-and-what-does-it-mean